### PR TITLE
http_respose_code kaldırıldı.

### DIFF
--- a/func.class.php
+++ b/func.class.php
@@ -119,7 +119,7 @@ class Func
 	public static function json($data, $code)
 	{
 		header('Content-type: application/json; charset: utf8');
-		http_response_code($code);
+		header('HTTP/1.1 '.$code);
 		return json_encode($data);
 	}
 }


### PR DESCRIPTION
PHP 5.4 ve üstünde çalışan http_response_code fonksiyonu klasik header
fonksiyonu ile değiştirildi